### PR TITLE
Fix `=ge=` in supported-rsql-operators.md

### DIFF
--- a/docs/read/supported-rsql-operators.md
+++ b/docs/read/supported-rsql-operators.md
@@ -14,7 +14,7 @@ DB2Rest supports the following RSQL operators.
 | >           | >             | greater than            | [X]       |
 | =gt=        | >             | greater than            | [X]       |
 | >=          | >=            | greater than or equal   | [X]       |
-| =gt=        | >             | greater than or equal   | [X]       |
+| =ge=        | >             | greater than or equal   | [X]       |
 | \<          | \<             | less than               | [X]       |
 | =lt=        | \<             | less than               | [X]       |
 | \<=          | \<=            | less than or equal      | [X]       |


### PR DESCRIPTION
As mentioned by @MichalisDBA in issue comment https://github.com/kdhrubo/db2rest/issues/437#issuecomment-2041964403