### PR TITLE
Fix url in Docusaurus config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -19,7 +19,7 @@ const config = {
   favicon: 'img/favicon.svg',
 
   // Set the production url of your site here
-  url: 'https://db2rest.com/',
+  url: 'https://db2rest.com',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/',


### PR DESCRIPTION
- We shouldn't have included the `baseUrl` string part `/` at the end of the `url`, so removing it, which hopefully "just fixes" the Algolia search ignoring 104 pages under `/docs` issue after a new crawl !!!