### PR TITLE
remove replaceSearchResultPathname in docusaurus.config.js

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -171,10 +171,10 @@ const config = {
         // externalUrlRegex: 'external\\.com|domain\\.com',
   
         // Optional: Replace parts of the item URLs from Algolia. Useful when using the same search index for multiple deployments using a different baseUrl. You can use regexp or string in the `from` param. For example: localhost:3000 vs myCompany.com/docs
-        replaceSearchResultPathname: {
-          from: '/docs/', // or as RegExp: /\/docs\//
-          to: '/',
-        },
+        // replaceSearchResultPathname: {
+        //  from: '/docs/', // or as RegExp: /\/docs\//
+        //  to: '/',
+        // },
   
         // Optional: Algolia search parameters
         searchParameters: {},


### PR DESCRIPTION
- hopefully this further fixes the Ignored pages which are not being crawled and instead skipped by Algolia when they are under /doc and /blog ?

