### PR TITLE
Fixes duplicate Title on website landing page

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -33,9 +33,7 @@ function HomepageHeader() {
 export default function Home() {
   const {siteConfig} = useDocusaurusContext();
   return (
-    <Layout
-      title={`${siteConfig.title}`}
-      description="Open Source REST DATA API for Databases. Build Intelligent Applications Faster <head />">
+    <Layout>
       <HomepageHeader />
       <main>
         <HomepageFeatures />


### PR DESCRIPTION
- removed `siteConfig.title` and `description` from the `<Layout>` portion as mentioned in https://github.com/facebook/docusaurus/pull/7362