### PR TITLE
Fix algolia URL navigation links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -177,10 +177,10 @@ const config = {
         // externalUrlRegex: 'external\\.com|domain\\.com',
   
         // Optional: Replace parts of the item URLs from Algolia. Useful when using the same search index for multiple deployments using a different baseUrl. You can use regexp or string in the `from` param. For example: localhost:3000 vs myCompany.com/docs
-        replaceSearchResultPathname: {
-          from: '/docs/', // or as RegExp: /\/docs\//
-          to: '/',
-        },
+        // replaceSearchResultPathname: {
+        //   from: '/docs/', // or as RegExp: /\/docs\//
+        //   to: '/',
+        // },
   
         // Optional: Algolia search parameters
         searchParameters: {},


### PR DESCRIPTION
- we want to keep `/docs/` paths and not replace them. Otherwise we get 404 broken links for Algolia search results