### PR TITLE
Added documentation page for schema api feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ yarn-debug.log*
 yarn-error.log*
 .yarn/install-state.gz
 .yarnrc.yml
+/.idea/

--- a/docs/multidb/_category_.json
+++ b/docs/multidb/_category_.json
@@ -1,7 +1,7 @@
 {
 
   "label": "Connect Multiple Databases",
-  "position": 45,
+  "position": 49,
   "link": {
     "type": "generated-index",
     "description": "Guide on how to connect and work with multiple databases."

--- a/docs/multidb/connect-multiple-db.mdx
+++ b/docs/multidb/connect-multiple-db.mdx
@@ -83,6 +83,7 @@ In this method the configuration will be loaded from YAML file.
 
 Create a Yaml file with name format `application-{profile}.yml` - for example `application-local.yml` file as shown below. In this case, the
 profile name is `local`. In this way you can create profile files for `dev`, `prod` etc.
+When no profile is used, the file name is just `application.yml`
 
 ```yaml
 

--- a/docs/remoteprocedurecall/_category_.json
+++ b/docs/remoteprocedurecall/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Remote Procedure Call",
-  "position": 45,
+  "position": 47,
   "link": {
     "type": "generated-index",
     "description": "Detailed guide to invoke stored procedures and functions over REST."

--- a/docs/schema/_category_.json
+++ b/docs/schema/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Database schema",
+  "position": 45,
+  "link": {
+    "type": "generated-index",
+    "description": "Detailed guide to find info about the database schema, tables with columns and views over REST."
+  }
+}

--- a/docs/schema/database-schema.mdx
+++ b/docs/schema/database-schema.mdx
@@ -1,0 +1,68 @@
+---
+sidebar_position: 2
+---
+
+# Database meta information
+
+
+DB2Rest makes it very easy to view the database schema, all tables and views within an database schema as REST API.
+Optionally it will return all column information.
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+## Schema Endpoint
+
+The API endpoint for viewing the schema is `/{dbId}/$schemas?columns=true`, where `dbId` is the configured database identifier.
+
+
+<Tabs>
+    <TabItem value="cURL" label="cURL" default>
+
+        ```bash
+
+        curl --request GET \
+        --url 'http://localhost:8080/v1/rdbms/pgsqldb/$schemas?columns=true' \
+        -H 'Accept: application/json'
+
+        ```
+    </TabItem>
+    <TabItem value="httpie" label="HTTPie">
+        ```bash
+
+        http GET 'http://localhost:8080/v1/rdbms/pgsqldb/$schemas?columns=true' \
+        'Accept:application/json'
+
+        ```
+    </TabItem>
+
+</Tabs>
+
+The response is shown below:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 324
+
+[
+    {
+        schema: "public",
+        name: "categories",
+        type: "TABLE",
+        columns: [
+            {
+                name: "category_id",
+                pk: true,
+                dataType: "int4"
+            },
+            {
+                name: "name",
+                pk: false,
+                dataType: "varchar"
+            }
+        ]
+    },
+    ...
+]
+```


### PR DESCRIPTION
The documentation for the api: http://localhost:8080/v1/rdbms/mydb/$schemas?columns=true seems missing, this adds the minimal info for api-users