### PR TITLE
Fix doc's mysql create table statement.

### DIFF
--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -39,13 +39,12 @@ CREATE TABLE employee (
 **MySQL**
 
 ```sql
-CREATE TABLE `employee` (
-  `emp_id` int unsigned NOT NULL AUTO_INCREMENT,
-  `first_name` varchar(100) NOT NULL,
-  `last_name` varchar(150) NOT NULL,
-  `create_date` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
-  `is_active` tinyint(1) DEFAULT '1',
-  PRIMARY KEY (`emp_id`)
+CREATE TABLE employee (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    first_name VARCHAR(50) NOT NULL,
+    last_name VARCHAR(50) NOT NULL,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    created_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 ```
 

--- a/docs/run-db2rest-on-docker.md
+++ b/docs/run-db2rest-on-docker.md
@@ -38,13 +38,12 @@ CREATE TABLE employee (
 **MySQL**
 
 ```sql
-CREATE TABLE `employee` (
-  `emp_id` int unsigned NOT NULL AUTO_INCREMENT,
-  `first_name` varchar(100) NOT NULL,
-  `last_name` varchar(150) NOT NULL,
-  `create_date` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
-  `is_active` tinyint(1) DEFAULT '1',
-  PRIMARY KEY (`emp_id`)
+CREATE TABLE employee (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    first_name VARCHAR(50) NOT NULL,
+    last_name VARCHAR(50) NOT NULL,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    created_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 ```
 


### PR DESCRIPTION
Hi, this is my first time contributing to an open-source project. I might be missing something, so please let me know if anything looks wrong — I’ll be happy to fix it right away.

In your documentation (specifically, the [intro](https://db2rest.com/docs/intro#pre-requisite) and [run-db2rest-on-docker](https://db2rest.com/docs/run-db2rest-on-docker#prerequisite)), the MySQL table creation syntax seemed different from the PostgreSQL example provided earlier. I updated the MySQL example to make it consistent.

The original MySQL example was:

```sql
CREATE TABLE `employee` (
  `emp_id` int unsigned NOT NULL AUTO_INCREMENT,
  `first_name` varchar(100) NOT NULL,
  `last_name` varchar(150) NOT NULL,
  `create_date` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
  `is_active` tinyint(1) DEFAULT '1',
  PRIMARY KEY (`emp_id`)
);
```

When using this syntax, the following request failed.:
<img width="1105" height="254" alt="image" src="https://github.com/user-attachments/assets/50808d40-78b0-4fb5-8ad9-fac5bd764f6c" />


To resolve the issue, I modified the table definition as below:

```sql
CREATE TABLE employee (
    id INT AUTO_INCREMENT PRIMARY KEY,
    first_name VARCHAR(50) NOT NULL,
    last_name VARCHAR(50) NOT NULL,
    email VARCHAR(255) NOT NULL UNIQUE,
    created_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
);
```